### PR TITLE
Implement new boundary conditions (OUT and DOWN)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeneralizedSasakiNakamura"
 uuid = "7d2aac85-6cc1-40c7-a4aa-e1a43f13f131"
 authors = ["Rico Ka Lok Lo"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/docs/src/APIs.md
+++ b/docs/src/APIs.md
@@ -42,6 +42,8 @@ This is an enum type that can take either one of the two values
 | :--- | :--- |
 | `IN` | purely ingoing at the horizon | 
 | `UP` | purely outgoing at infinity |
+| `OUT` | purely outgoing at the horizon |
+| `DOWN`| purely ingoing at infinity |
 
 #### NormalizationConvention
 This is an enum type that can take either one of the two values

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,6 +33,8 @@ Works well at *both low and high frequencies*, and takes only a few tens of mill
 
 *(There was no caching! We solved the equation on-the-fly! The notebook generating this animation can be found [here](https://github.com/ricokaloklo/GeneralizedSasakiNakamura.jl/blob/main/examples/realtime-demo.ipynb))*
 
+Static/zero-frequency solutions are solved analytically with Gauss hypergeometric functions.
+
 ### Solutions that are accurate everywhere
 Numerical solutions are *smoothly stitched* to analytical ansatzes near the horizon and infinity at user-specified locations `rsin` and `rsout` respectively:
 

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -353,7 +353,14 @@ end
     Teukolsky_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=3, infinity_expansion_order::Int=6, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
 
 Compute the Teukolsky function for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
-and boundary condition (specified by `boundary_condition` which can be either `IN` for purely-ingoing at the horizon or `UP` for purely-outgoing at infinity) using the GSN formalism with [`GSN_radial`](@ref GeneralizedSasakiNakamura.GSN_radial).
+and boundary condition specified by `boundary_condition`, which can be either
+
+    - `IN` for purely-ingoing at the horizon,
+    - `UP` for purely-outgoing at infinity,
+    - `OUT` for purely-outgoing at the horizon,
+    - `DOWN` for purely-ingoing at infinity.
+
+Note that the `OUT` and `DOWN` solutions are constructed by linearly combining the `IN` and `UP` solutions, respectively.
 
 The full GSN solution is converted to the corresponding Teukolsky solution $(R(r), dR/dr)$ and 
 the incidence, reflection and transmission amplitude are converted from the GSN formalism to the Teukolsky formalism 
@@ -383,6 +390,18 @@ function Teukolsky_radial(
             transmission_amplitude_conv_factor = ConversionFactors.Ctrans(s, m, a, omega, gsn_func.mode.lambda)
             incidence_amplitude = ConversionFactors.Cinc(s, m, a, omega, gsn_func.mode.lambda) * gsn_func.incidence_amplitude / transmission_amplitude_conv_factor
             reflection_amplitude = ConversionFactors.Cref(s, m, a, omega, gsn_func.mode.lambda) * gsn_func.reflection_amplitude / transmission_amplitude_conv_factor
+        elseif gsn_func.boundary_condition == DOWN
+            # NOTE While for a DOWN solution, it makes no physical sense to talk about incidence and reflection amplitude
+            # The "transmission amplitude" transforms like Binc
+            transmission_amplitude_conv_factor = ConversionFactors.Binc(s, m, a, omega, gsn_func.mode.lambda)
+            incidence_amplitude = missing
+            reflection_amplitude = missing
+        elseif gsn_func.boundary_condition == OUT
+            # NOTE While for a OUT solution, it makes no physical sense to talk about incidence and reflection amplitude
+            # The "tranmission amplitude" transforms like Cinc
+            transmission_amplitude_conv_factor = ConversionFactors.Cinc(s, m, a, omega, gsn_func.mode.lambda)
+            incidence_amplitude = missing
+            reflection_amplitude = missing
         else
             error("Does not understand the boundary condition applied to the solution")
         end

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -19,11 +19,14 @@ using DifferentialEquations # Should have been compiled by now
 export GSN_radial, Teukolsky_radial
 
 # IN for purely-ingoing at the horizon and UP for purely-outgoing at infinity
+# OUT for purely-outgoing at the horizon and DOWN for purely-ingoing at infinity
 @enum BoundaryCondition begin
     IN = 1
     UP = 2
+    OUT = 3
+    DOWN = 4
 end
-export IN, UP # Use these to specify the BC
+export IN, UP, OUT, DOWN # Use these to specify the BC
 
 # Normalization convention, UNIT_GSN_TRANS means that the transmission amplitude for GSN functions is normalized to 1, vice versa
 @enum NormalizationConvention begin
@@ -145,7 +148,14 @@ end
     GSN_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=3, infinity_expansion_order::Int=6, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
 
 Compute the GSN function for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
-and boundary condition (specified by `boundary_condition` which can be either `IN` for purely-ingoing at the horizon or `UP` for purely-outgoing at infinity).
+and boundary condition specified by `boundary_condition`, which can be either
+
+    - `IN` for purely-ingoing at the horizon,
+    - `UP` for purely-outgoing at infinity,
+    - `OUT` for purely-outgoing at the horizon,
+    - `DOWN` for purely-ingoing at infinity.
+
+Note that the `OUT` and `DOWN` solutions are constructed by linearly combining the `IN` and `UP` solutions, respectively.
 
 The GSN function is numerically solved in the interval of *tortoise coordinates* $r_{*} \in$ `[rsin, rsout]` using the ODE solver (from `DifferentialEquations.jl`) specified by `ODE_algorithm` (default: `Vern9()`) 
 with tolerance specified by `tolerance` (default: `1e-12`). By default the data type used is `ComplexF64` (i.e. double-precision floating-point number) but it can be changed by 
@@ -230,6 +240,66 @@ function GSN_radial(
                 missing,
                 Phiupsoln,
                 semianalytical_Xupsoln,
+                UNIT_GSN_TRANS
+            )
+        elseif boundary_condition == DOWN
+            # Construct Xdown from Xin and Xup, instead of solving the ODE numerically with the boundary condition
+
+            # Solve for Xin *and* Xup first
+            Xin = GSN_radial(s, l, m, a, omega, IN, rsin, rsout, horizon_expansion_order=horizon_expansion_order, infinity_expansion_order=infinity_expansion_order, data_type=data_type, ODE_algorithm=ODE_algorithm, tolerance=tolerance)
+            Xup = GSN_radial(s, l, m, a, omega, UP, rsin, rsout, horizon_expansion_order=horizon_expansion_order, infinity_expansion_order=infinity_expansion_order, data_type=data_type, ODE_algorithm=ODE_algorithm, tolerance=tolerance)
+
+            # Xdown is a linear combination of Xin and Xup with the following coefficients
+            Binc = Xin.incidence_amplitude
+            Bref = Xin.reflection_amplitude
+            Ctrans = Xup.transmission_amplitude # Should really be just 1
+
+            _full_Xdown_solution(rs) = Binc^-1 .* (Xin.GSN_solution(rs) .- Bref/Ctrans .* Xup.GSN_solution(rs))
+
+            # These solutions are "normalized" in the sense that Xdown -> exp(-i*omega*rs) near infinity
+            return GSNRadialFunction(
+                Xin.mode,
+                DOWN,
+                rsin,
+                rsout,
+                horizon_expansion_order,
+                infinity_expansion_order,
+                data_type(1),
+                missing,
+                missing,
+                missing,
+                missing,
+                _full_Xdown_solution,
+                UNIT_GSN_TRANS
+            )
+        elseif boundary_condition == OUT
+            # Construct Xout from Xin and Xup, instead of solving the ODE numerically with the boundary condition
+
+            # Solve for Xin *and* Xup first
+            Xin = GSN_radial(s, l, m, a, omega, IN, rsin, rsout, horizon_expansion_order=horizon_expansion_order, infinity_expansion_order=infinity_expansion_order, data_type=data_type, ODE_algorithm=ODE_algorithm, tolerance=tolerance)
+            Xup = GSN_radial(s, l, m, a, omega, UP, rsin, rsout, horizon_expansion_order=horizon_expansion_order, infinity_expansion_order=infinity_expansion_order, data_type=data_type, ODE_algorithm=ODE_algorithm, tolerance=tolerance)
+
+            # Xout is a linear combination of Xin and Xup with the following coefficients
+            Btrans = Xin.transmission_amplitude # Should really be just 1
+            Cinc = Xup.incidence_amplitude
+            Cref = Xup.reflection_amplitude
+
+            _full_Xout_solution(rs) = Cinc^-1 .* (Xup.GSN_solution(rs) .- Cref/Btrans .* Xin.GSN_solution(rs))
+
+            # These solutions are "normalized" in the sense that Xout -> exp(i*p*rs) near the horizon
+            return GSNRadialFunction(
+                Xin.mode,
+                OUT,
+                rsin,
+                rsout,
+                horizon_expansion_order,
+                infinity_expansion_order,
+                data_type(1),
+                missing,
+                missing,
+                missing,
+                missing,
+                _full_Xout_solution,
                 UNIT_GSN_TRANS
             )
         else


### PR DESCRIPTION
In this PR, we implement two lesser-used but still useful boundary conditions 

- `OUT` for purely out-going at the horizon and
- `DOWN` purely in-going at infinity,

for both the GSN equation and the Teukolsky equation.

However, the implementation is only for non-zero frequencies, and there is no plan to implement the same for the static case since that is just math but with an even less apparent use case.