### PR TITLE
Ansatz order determination

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeneralizedSasakiNakamura"
 uuid = "7d2aac85-6cc1-40c7-a4aa-e1a43f13f131"
 authors = ["Rico Ka Lok Lo"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -286,20 +286,11 @@ function GSN_radial(
     end
 end
 
-@doc raw"""
-    GSN_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition)
-
-Compute the exact *static* (`omega = 0`) GSN function using Gauss hypergeometric functions 
-for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
-and boundary condition (specified by `boundary_condition` which can be either `IN` for purely-ingoing at the horizon or `UP` for purely-outgoing at infinity).
-
-Note that the GSN function is transformed from the exact Teukolsky function using the GSN transformation.
-"""
 function GSN_radial(
     s::Int, l::Int, m::Int, a, omega, boundary_condition
 )
     if omega != 0
-        error("Cannot compute the GSN function for a nonstatic (omega != 0) case without specifying rsin and rsout")
+        return GSN_radial(s, l, m, a, omega, boundary_condition, _DEFAULT_rsin, _DEFAULT_rsout)
     else
         teuk_func = Teukolsky_radial(s, l, m, a, omega, boundary_condition)
         GSN_solution = Solutions.Sasaki_Nakamura_function_from_Teukolsky_radial_function(s, m, a, omega, teuk_func.mode.lambda, teuk_func.Teukolsky_solution)
@@ -418,7 +409,7 @@ function Teukolsky_radial(
     s::Int, l::Int, m::Int, a, omega, boundary_condition
 )
     if omega != 0
-        error("Cannot compute the Teukolsky function for a nonstatic (omega != 0) case without specifying rsin and rsout")
+        return Teukolsky_radial(s, l, m, a, omega, boundary_condition, _DEFAULT_rsin, _DEFAULT_rsout)
     else
         # Compute the SWSH eigenvalue
         lambda = spin_weighted_spherical_eigenvalue(s, l, m)

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -18,6 +18,12 @@ using DifferentialEquations # Should have been compiled by now
 
 export GSN_radial, Teukolsky_radial
 
+# Default values
+_DEFAULT_rsin = -50
+_DEFAULT_rsout = 1000
+_DEFAULT_horizon_expansion_order = 3
+_DEFAULT_infinity_expansion_order = 6
+
 # IN for purely-ingoing at the horizon and UP for purely-outgoing at infinity
 # OUT for purely-outgoing at the horizon and DOWN for purely-ingoing at infinity
 @enum BoundaryCondition begin
@@ -109,7 +115,7 @@ function Base.show(io::IO, ::MIME"text/plain", teuk_func::TeukolskyRadialFunctio
 end
 
 @doc raw"""
-    GSN_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=3, infinity_expansion_order::Int=6, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
+    GSN_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=_DEFAULT_horizon_expansion_order, infinity_expansion_order::Int=_DEFAULT_infinity_expansion_order, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
 
 Compute the GSN function for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
 and boundary condition specified by `boundary_condition`, which can be either
@@ -136,7 +142,7 @@ Return a `GSNRadialFunction` object which contains all the information about the
 """
 function GSN_radial(
     s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout;
-    horizon_expansion_order::Int=3, infinity_expansion_order::Int=6,
+    horizon_expansion_order::Int=_DEFAULT_horizon_expansion_order, infinity_expansion_order::Int=_DEFAULT_infinity_expansion_order,
     data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE
 )
     if omega == 0
@@ -320,7 +326,7 @@ end
 (gsn_func::GSNRadialFunction)(rs) = gsn_func.GSN_solution(rs)[1] # Only return X(rs), discarding the first derivative
 
 @doc raw"""
-    Teukolsky_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=3, infinity_expansion_order::Int=6, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
+    Teukolsky_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout; horizon_expansion_order::Int=_DEFAULT_horizon_expansion_order, infinity_expansion_order::Int=_DEFAULT_infinity_expansion_order, data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE)
 
 Compute the Teukolsky function for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
 and boundary condition specified by `boundary_condition`, which can be either
@@ -341,7 +347,7 @@ In this case, only `s`, `l`, `m`, `a`, `omega`, `boundary_condition` will be par
 """
 function Teukolsky_radial(
     s::Int, l::Int, m::Int, a, omega, boundary_condition, rsin, rsout;
-    horizon_expansion_order::Int=3, infinity_expansion_order::Int=6,
+    horizon_expansion_order::Int=_DEFAULT_horizon_expansion_order, infinity_expansion_order::Int=_DEFAULT_infinity_expansion_order,
     data_type=Solutions._DEFAULTDATATYPE,  ODE_algorithm=Solutions._DEFAULTSOLVER, tolerance=Solutions._DEFAULTTOLERANCE
 )
     if omega == 0

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -90,6 +90,10 @@ function Base.show(io::IO, ::MIME"text/plain", gsn_func::GSNRadialFunction)
     print(io, ")")
 end
 
+function Base.show(io::IO, gsn_func::GSNRadialFunction)
+    print(io, "GSNRadialFunction(mode="); show(io, "text/plain", gsn_func.mode); print(", boundary_condition=$(gsn_func.boundary_condition))")
+end
+
 struct TeukolskyRadialFunction
     mode::Mode # Information about the mode
     boundary_condition::BoundaryCondition # The boundary condition that this radial function statisfies
@@ -112,6 +116,10 @@ function Base.show(io::IO, ::MIME"text/plain", teuk_func::TeukolskyRadialFunctio
     println(io, "    reflection_amplitude=$(teuk_func.reflection_amplitude),")
     println(io, "    normalization_convention=$(teuk_func.normalization_convention)")
     print(io, ")")
+end
+
+function Base.show(io::IO, teuk_func::TeukolskyRadialFunction)
+    print(io, "TeukolskyRadialFunction(mode="); show(io, "text/plain", teuk_func.mode); print(", boundary_condition=$(teuk_func.boundary_condition))")
 end
 
 @doc raw"""

--- a/src/GeneralizedSasakiNakamura.jl
+++ b/src/GeneralizedSasakiNakamura.jl
@@ -398,13 +398,6 @@ function Teukolsky_radial(
     end
 end
 
-@doc raw"""
-    Teukolsky_radial(s::Int, l::Int, m::Int, a, omega, boundary_condition)
-
-Compute the exact *static* (`omega = 0`) Teukolsky function using Gauss hypergeometric functions 
-for a given mode (specified by `s` the spin weight, `l` the harmonic index, `m` the azimuthal index, `a` the Kerr spin parameter, and `omega` the frequency) 
-and boundary condition (specified by `boundary_condition` which can be either `IN` for purely-ingoing at the horizon or `UP` for purely-outgoing at infinity).
-"""
 function Teukolsky_radial(
     s::Int, l::Int, m::Int, a, omega, boundary_condition
 )

--- a/src/Solutions.jl
+++ b/src/Solutions.jl
@@ -682,6 +682,36 @@ function semianalytical_Xup(s, m, a, omega, lambda, Xupsoln, rsin, rsout, horizo
     end 
 end
 
+function check_XinXup_sanity(Xin, Xup; tolerance=1e-6)
+    #=
+    Check if the X_in and X_up solutions are sane by checking if the identity
+
+    Binc/Cinc = (p*c0)/(omega*eta(r_+)) [note: this is Eq. (42) in the paper]
+
+    is satisfied within a specified tolerance
+    =#
+
+    # Check if the modes are the same
+    if Xin.mode != Xup.mode
+        throw(ArgumentError("The modes of Xin and Xup are different"))
+    end
+
+    # Calculate what Binc/Cinc is expected to be
+    p = Xin.mode.omega - Xin.mode.m*omega_horizon(Xin.mode.a)
+    c0 = eta_coefficient(Xin.mode.s, Xin.mode.m, Xin.mode.a, Xin.mode.omega, Xin.mode.lambda, 0)
+    eta_at_rplus = eta(Xin.mode.s, Xin.mode.m, Xin.mode.a, Xin.mode.omega, Xin.mode.lambda, r_plus(Xin.mode.a))
+    expected_value = (p*c0)/(Xin.mode.omega*eta_at_rplus)
+
+    # Calculate the actual value
+    actual_value = Xin.incidence_amplitude/Xup.incidence_amplitude
+
+    if abs(actual_value - expected_value) > tolerance
+        return false
+    else
+        return true
+    end
+end
+
 # Some helper functions for static modes
 function x_from_r(a, r)
     #=

--- a/src/Transformation.jl
+++ b/src/Transformation.jl
@@ -4,7 +4,7 @@ using ForwardDiff
 using ..Kerr
 using ..Potentials
 
-export alpha, alpha_prime, beta, beta_prime, eta, eta_prime
+export alpha, alpha_prime, beta, beta_prime, eta_coefficient, eta, eta_prime
 
 const I = 1im # Mathematica being Mathematica
 


### PR DESCRIPTION
In this PR, we implement automatic ansatz order determination. This is done by solving $X^{\text{in}}$ and $X^{\text{up}}$ and extracting their respective incidence amplitudes, and comparing the ratio of them with the expected value given $s, \ell, m, a, \omega$.

If the check fails, the ansatz order used in the horizon expansion and the infinity expansion are raised, until a pre-determined tolerance (hardcoded to be 1e-6 for now) is reached.